### PR TITLE
Add linting GitHub Actions workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+name: bandit and flake8
+
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # https://endoflife.date/python
+        # https://github.com/actions/runner-images
+        python-version:
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          - '3.12'
+          - '3.13'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: set up python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - run: pip install -r requirements.txt
+
+      - run: pip install flake8 bandit
+
+      - run: flake8 --max-line-length 120 *.py
+
+      - run: bandit *.py

--- a/metrics.py
+++ b/metrics.py
@@ -361,7 +361,7 @@ def signal_handler(sig, frame):
 if __name__ == "__main__":
     # Get MongoDB URI and Prometheus port from environment variables
     mongodb_uri = os.getenv("MONGODB_URI", "mongodb://mongodb:27017/")
-    prometheus_port = 8000#int(os.getenv("PROMETHEUS_PORT", "8000"))
+    prometheus_port = 8000
 
     # Handle shutdown signals
     signal.signal(signal.SIGINT, signal_handler)


### PR DESCRIPTION
This patch adds a GitHub Actions workflow to automatically run `flake8` and `bandit` on commits and pull requests.