### PR TITLE
Prevent adding development files to container images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,11 @@ FROM python:3.13-slim
 # Set the working directory
 WORKDIR /app
 
-COPY . /app
+COPY LICENSE metrics.py /app/
 
 # Install dependencies
-RUN pip install --no-cache-dir -r requirements.txt
+RUN --mount=type=bind,source=requirements.txt,target=/tmp/requirements.txt \
+    pip install --no-cache-dir --requirement /tmp/requirements.txt
 
 # Expose the Prometheus port
 EXPOSE 8000


### PR DESCRIPTION
This patch prevents development files like the git repository or the the environment file from ending up in the container. The latter was especially annoying since it was overwriting the default location of MongoDB configured in the exporter.